### PR TITLE
implement GAMMA and POWERLINE configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build
+
+VVUVCKit.xcodeproj/*
+

--- a/USBBusProber/BusProber.m
+++ b/USBBusProber/BusProber.m
@@ -246,7 +246,7 @@ static void DeviceRemoved(void *refCon, io_iterator_t iterator)
 		sprintf((char *)buf, "%s (0x%x)", USBErrorToString(error), error );
 		[thisDevice addProperty:"Port Information:" withValue:buf  atDepth:ROOT_LEVEL];
 
-		NSLog(@"USB Prober: GetUSBDeviceInformation() for device @%8x failed with %s", (uint32_t)[thisDevice locationID], USBErrorToString(error));
+		//NSLog(@"USB Prober: GetUSBDeviceInformation() for device @%8x failed with %s", (uint32_t)[thisDevice locationID], USBErrorToString(error));
 	}
 	
 	// Log the number of endpoints for each configuration

--- a/USBBusProber/USBBusProber-Info.plist
+++ b/USBBusProber/USBBusProber-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.Vidvox.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/UVC Test App/UVC Test App-Info.plist
+++ b/UVC Test App/UVC Test App-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.Vidvox.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/VVUVCKit.xcodeproj/project.pbxproj
+++ b/VVUVCKit.xcodeproj/project.pbxproj
@@ -15,7 +15,7 @@
 		962773A919D56C69001EDD16 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 962773A719D56C69001EDD16 /* Credits.rtf */; };
 		962773AC19D56C69001EDD16 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 962773AB19D56C69001EDD16 /* AppDelegate.m */; };
 		962773AF19D56C69001EDD16 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 962773AD19D56C69001EDD16 /* MainMenu.xib */; };
-		962773B719D56C98001EDD16 /* VVUVCKit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 96C2712E19D5695B00705982 /* VVUVCKit.framework */; };
+		962773B719D56C98001EDD16 /* VVUVCKit.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 96C2712E19D5695B00705982 /* VVUVCKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		962773BA19D56D27001EDD16 /* AVCaptureVideoSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 962773B919D56D27001EDD16 /* AVCaptureVideoSource.m */; };
 		962773BC19D5C35C001EDD16 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 962773BB19D5C35C001EDD16 /* AVFoundation.framework */; };
 		962773BE19D5C360001EDD16 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 962773BD19D5C360001EDD16 /* CoreVideo.framework */; };
@@ -81,7 +81,7 @@
 		96CCFEC019D6C0BE000B1B2C /* OutlineViewAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 96CCFEBC19D6C0BE000B1B2C /* OutlineViewAdditions.m */; };
 		96CCFEC319D6C0C5000B1B2C /* ExtensionSelector.h in Headers */ = {isa = PBXBuildFile; fileRef = 96CCFEC119D6C0C5000B1B2C /* ExtensionSelector.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		96CCFEC419D6C0C5000B1B2C /* ExtensionSelector.m in Sources */ = {isa = PBXBuildFile; fileRef = 96CCFEC219D6C0C5000B1B2C /* ExtensionSelector.m */; };
-		96D296F819D6C4070030185B /* USBBusProber.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 96CCFE5F19D6BFAD000B1B2C /* USBBusProber.framework */; };
+		96D296F819D6C4070030185B /* USBBusProber.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 96CCFE5F19D6BFAD000B1B2C /* USBBusProber.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -512,8 +512,16 @@
 		96C2712519D5695B00705982 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0510;
+				LastUpgradeCheck = 0730;
 				ORGANIZATIONNAME = Vidvox;
+				TargetAttributes = {
+					96C2712D19D5695B00705982 = {
+						DevelopmentTeam = CDB4DSECA2;
+					};
+					96CCFE5E19D6BFAD000B1B2C = {
+						DevelopmentTeam = CDB4DSECA2;
+					};
+				};
 			};
 			buildConfigurationList = 96C2712819D5695B00705982 /* Build configuration list for PBXProject "VVUVCKit" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -683,6 +691,7 @@
 				GCC_PREFIX_HEADER = "UVC Test App/UVC Test App-Prefix.pch";
 				INFOPLIST_FILE = "UVC Test App/UVC Test App-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Vidvox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -696,6 +705,7 @@
 				GCC_PREFIX_HEADER = "UVC Test App/UVC Test App-Prefix.pch";
 				INFOPLIST_FILE = "UVC Test App/UVC Test App-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Vidvox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;
 			};
@@ -705,7 +715,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -714,6 +723,7 @@
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_ENABLE_OBJC_EXCEPTIONS = YES;
@@ -737,7 +747,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
@@ -769,6 +778,7 @@
 				GCC_PREFIX_HEADER = "VVUVCKit/VVUVCKit-Prefix.pch";
 				INFOPLIST_FILE = "VVUVCKit/VVUVCKit-Info.plist";
 				INSTALL_PATH = "@rpath";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Vidvox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = framework;
 			};
@@ -785,6 +795,7 @@
 				GCC_PREFIX_HEADER = "VVUVCKit/VVUVCKit-Prefix.pch";
 				INFOPLIST_FILE = "VVUVCKit/VVUVCKit-Info.plist";
 				INSTALL_PATH = "@rpath";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Vidvox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = framework;
 			};
@@ -801,6 +812,7 @@
 				GCC_PREFIX_HEADER = "USBBusProber/USBBusProber-Prefix.pch";
 				INFOPLIST_FILE = "USBBusProber/USBBusProber-Info.plist";
 				INSTALL_PATH = "@rpath";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Vidvox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = framework;
 			};
@@ -817,6 +829,7 @@
 				GCC_PREFIX_HEADER = "USBBusProber/USBBusProber-Prefix.pch";
 				INFOPLIST_FILE = "USBBusProber/USBBusProber-Info.plist";
 				INSTALL_PATH = "@rpath";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.Vidvox.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = framework;
 			};

--- a/VVUVCKit.xcodeproj/xcshareddata/xcschemes/UVC Test App.xcscheme
+++ b/VVUVCKit.xcodeproj/xcshareddata/xcschemes/UVC Test App.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0510"
+   LastUpgradeVersion = "0730"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,17 +38,21 @@
             ReferencedContainer = "container:VVUVCKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9627739B19D56C69001EDD16"
@@ -61,12 +65,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "9627739B19D56C69001EDD16"

--- a/VVUVCKit/VVUVCController.h
+++ b/VVUVCKit/VVUVCController.h
@@ -72,10 +72,12 @@ extern uvc_control_info_t	_backlightCtrl;
 extern uvc_control_info_t	_brightCtrl;
 extern uvc_control_info_t	_contrastCtrl;
 extern uvc_control_info_t	_gainCtrl;
+extern uvc_control_info_t	_powerLineCtrl;
 extern uvc_control_info_t	_autoHueCtrl;
 extern uvc_control_info_t	_hueCtrl;
 extern uvc_control_info_t	_saturationCtrl;
 extern uvc_control_info_t	_sharpnessCtrl;
+extern uvc_control_info_t	_gammaCtrl;
 extern uvc_control_info_t	_whiteBalanceAutoTempCtrl;
 extern uvc_control_info_t	_whiteBalanceTempCtrl;
 
@@ -128,10 +130,12 @@ This is probably the only class you'll have to work with in this framework.  The
 	uvc_param			bright;
 	uvc_param			contrast;
 	uvc_param			gain;
+	uvc_param			powerLine;
 	uvc_param			autoHue;
 	uvc_param			hue;
 	uvc_param			saturation;
 	uvc_param			sharpness;
+	uvc_param			gamma;
 	uvc_param			autoWhiteBalance;
 	uvc_param			whiteBalance;
 	
@@ -308,6 +312,18 @@ This is probably the only class you'll have to work with in this framework.  The
 - (long) minGain;
 ///	The max gain value
 - (long) maxGain;
+///	Sets the powerline to the passed value
+- (void) setPowerLine:(long)n;
+///	Gets the powerline value currently being used by the camera
+- (long) powerLine;
+///	Whether or not this camera supports the powerline parameter
+- (BOOL) powerLineSupported;
+///	Resets the powerline value to the hardware-defined default
+- (void) resetPowerLine;
+///	The min powerline value
+- (long) minPowerLine;
+///	The max powerline value
+- (long) maxPowerLine;
 ///	Sets the auto hue to the passed value
 - (void) setAutoHue:(BOOL)n;
 ///	The auto hue value currently being used by the camera
@@ -352,6 +368,18 @@ This is probably the only class you'll have to work with in this framework.  The
 - (long) minSharpness;
 ///	The max sharpness value
 - (long) maxSharpness;
+///	Sets the gamma to the passed value
+- (void) setGamma:(long)n;
+///	Gets the gamma value currently being used by the camera
+- (long) gamma;
+///	Whether or not this camera supports the gamma parameter
+- (BOOL) gammaSupported;
+///	Resets the gamma value to the hardware-defined default
+- (void) resetGamma;
+///	The min gamma value
+- (long) minGamma;
+///	The max gamma value
+- (long) maxGamma;
 ///	Sets the auto white balance to the passed value
 - (void) setAutoWhiteBalance:(BOOL)n;
 ///	Gets the auto white balance value currently being used by the camera

--- a/VVUVCKit/VVUVCController.m
+++ b/VVUVCKit/VVUVCController.m
@@ -319,7 +319,7 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 }
 */
 - (id) initWithDeviceIDString:(NSString *)n	{
-	NSLog(@"%s ... %@",__func__,n);
+	//NSLog(@"%s ... %@",__func__,n);
 	if (n != nil)	{
 		UInt32		locationID = 0;
 		sscanf([n UTF8String], "0x%8x",(unsigned int *)&locationID);
@@ -329,7 +329,7 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 	return nil;
 }
 - (id) initWithLocationID:(UInt32)locationID {
-	NSLog(@"%s ... %d, %X",__func__,(unsigned int)locationID,(unsigned int)locationID);
+	//NSLog(@"%s ... %d, %X",__func__,(unsigned int)locationID,(unsigned int)locationID);
 	self = [super init];
 	if (self!=nil) {
 		//	technically i don't need to set these here- they're calculated below from the BusProber, but default values are good, m'kay?

--- a/VVUVCKit/VVUVCController.m
+++ b/VVUVCKit/VVUVCController.m
@@ -109,10 +109,12 @@ uvc_control_info_t	_backlightCtrl;
 uvc_control_info_t	_brightCtrl;
 uvc_control_info_t	_contrastCtrl;
 uvc_control_info_t	_gainCtrl;
+uvc_control_info_t	_powerLineCtrl;
 uvc_control_info_t	_autoHueCtrl;
 uvc_control_info_t	_hueCtrl;
 uvc_control_info_t	_saturationCtrl;
 uvc_control_info_t	_sharpnessCtrl;
+uvc_control_info_t	_gammaCtrl;
 uvc_control_info_t	_whiteBalanceAutoTempCtrl;
 uvc_control_info_t	_whiteBalanceTempCtrl;
 
@@ -252,6 +254,14 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 	_gainCtrl.hasDef = YES;
 	_gainCtrl.isSigned = NO;
 	_gainCtrl.isRelative = NO;
+	_powerLineCtrl.unit = UVC_PROCESSING_UNIT_ID;
+	_powerLineCtrl.selector = UVC_PU_POWER_LINE_FREQUENCY_CONTROL;
+	_powerLineCtrl.intendedSize = 2;
+	_powerLineCtrl.hasMin = YES;
+	_powerLineCtrl.hasMax = YES;
+	_powerLineCtrl.hasDef = YES;
+	_powerLineCtrl.isSigned = NO;
+	_powerLineCtrl.isRelative = NO;
 	_autoHueCtrl.unit = UVC_PROCESSING_UNIT_ID;
 	_autoHueCtrl.selector = UVC_PU_HUE_AUTO_CONTROL;
 	_autoHueCtrl.intendedSize = 2;
@@ -284,6 +294,14 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 	_sharpnessCtrl.hasDef = YES;
 	_sharpnessCtrl.isSigned = NO;
 	_sharpnessCtrl.isRelative = NO;
+	_gammaCtrl.unit = UVC_PROCESSING_UNIT_ID;
+	_gammaCtrl.selector = UVC_PU_GAMMA_CONTROL;
+	_gammaCtrl.intendedSize = 2;
+	_gammaCtrl.hasMin = YES;
+	_gammaCtrl.hasMax = YES;
+	_gammaCtrl.hasDef = YES;
+	_gammaCtrl.isSigned = NO;
+	_gammaCtrl.isRelative = NO;
 	_whiteBalanceAutoTempCtrl.unit = UVC_PROCESSING_UNIT_ID;
 	_whiteBalanceAutoTempCtrl.selector = UVC_PU_WHITE_BALANCE_TEMPERATURE_AUTO_CONTROL;
 	_whiteBalanceAutoTempCtrl.intendedSize = 1;
@@ -321,9 +339,9 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 - (id) initWithDeviceIDString:(NSString *)n	{
 	//NSLog(@"%s ... %@",__func__,n);
 	if (n != nil)	{
-		UInt32		locationID = 0;
-		sscanf([n UTF8String], "0x%8x",(unsigned int *)&locationID);
-		return [self initWithLocationID:locationID];
+		unsigned int locationID = 0;
+		sscanf([n UTF8String], "0x%8x",&locationID);
+		if (locationID) return [self initWithLocationID:locationID];
 	}
 	[self release];
 	return nil;
@@ -487,13 +505,17 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 						[self generalInit];
 						successfullInit = YES;
 						//	clean up the plugin interface
-						IODestroyPlugInInterface(plugInInterface);
-						plugInInterface = NULL;
+						if (plugInInterface!=NULL)	{
+							IODestroyPlugInInterface(plugInInterface);
+							plugInInterface = NULL;
+						}
 						break;
 					}
 					//	clean up the plugin interface
-					IODestroyPlugInInterface(plugInInterface);
-					plugInInterface = NULL;
+					if (plugInInterface!=NULL)	{
+						IODestroyPlugInInterface(plugInInterface);
+						plugInInterface = NULL;
+					}
 				}
 			}
 			
@@ -582,10 +604,12 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 	bright.ctrlInfo = &_brightCtrl;
 	contrast.ctrlInfo = &_contrastCtrl;
 	gain.ctrlInfo = &_gainCtrl;
+	powerLine.ctrlInfo = &_powerLineCtrl;
 	autoHue.ctrlInfo = &_autoHueCtrl;
 	hue.ctrlInfo = &_hueCtrl;
 	saturation.ctrlInfo = &_saturationCtrl;
 	sharpness.ctrlInfo = &_sharpnessCtrl;
+	gamma.ctrlInfo = &_gammaCtrl;
 	autoWhiteBalance.ctrlInfo = &_whiteBalanceAutoTempCtrl;
 	whiteBalance.ctrlInfo = &_whiteBalanceTempCtrl;
 	
@@ -651,10 +675,12 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 	[returnMe setObject:[NSNumber numberWithLong:[self bright]] forKey:@"bright"];
 	[returnMe setObject:[NSNumber numberWithLong:[self contrast]] forKey:@"contrast"];
 	[returnMe setObject:[NSNumber numberWithLong:[self gain]] forKey:@"gain"];
+	[returnMe setObject:[NSNumber numberWithLong:[self powerLine]] forKey:@"powerLine"];
 	[returnMe setObject:[NSNumber numberWithBool:[self autoHue]] forKey:@"autoHue"];
 	[returnMe setObject:[NSNumber numberWithLong:[self hue]] forKey:@"hue"];
 	[returnMe setObject:[NSNumber numberWithLong:[self saturation]] forKey:@"saturation"];
 	[returnMe setObject:[NSNumber numberWithLong:[self sharpness]] forKey:@"sharpness"];
+	[returnMe setObject:[NSNumber numberWithLong:[self gamma]] forKey:@"gamma"];
 	[returnMe setObject:[NSNumber numberWithBool:[self autoWhiteBalance]] forKey:@"autoWhiteBalance"];
 	[returnMe setObject:[NSNumber numberWithLong:[self whiteBalance]] forKey:@"whiteBalance"];
 	return returnMe;
@@ -750,6 +776,11 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 		[self setGain:[tmpNum longValue]];
 	}
 	
+	tmpNum = [s objectForKey:@"powerLine"];
+	if (tmpNum!=nil)	{
+		[self setPowerLine:[tmpNum longValue]];
+	}
+	
 	tmpNum = [s objectForKey:@"autoHue"];
 	if (tmpNum!=nil)	{
 		[self setAutoHue:[tmpNum boolValue]];
@@ -768,6 +799,11 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 	tmpNum = [s objectForKey:@"sharpness"];
 	if (tmpNum!=nil)	{
 		[self setSharpness:[tmpNum longValue]];
+	}
+	
+	tmpNum = [s objectForKey:@"gamma"];
+	if (tmpNum!=nil)	{
+		[self setGamma:[tmpNum longValue]];
 	}
 	
 	tmpNum = [s objectForKey:@"autoWhiteBalance"];
@@ -901,10 +937,12 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 	[self _populateParam:&bright];
 	[self _populateParam:&contrast];
 	[self _populateParam:&gain];
+	[self _populateParam:&powerLine];
 	[self _populateParam:&autoHue];
 	[self _populateParam:&hue];
 	[self _populateParam:&saturation];
 	[self _populateParam:&sharpness];
+	[self _populateParam:&gamma];
 	
 	[self _populateParam:&autoWhiteBalance];
 	
@@ -930,10 +968,12 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 	NSLogParam(@"\t\t bright",bright);
 	NSLogParam(@"\t\t contrast",contrast);
 	NSLogParam(@"\t\t gain",gain);
+	NSLogParam(@"\t\t power",powerLine);
 	NSLogParam(@"\t\t auto hue",autoHue);
 	NSLogParam(@"\t\t hue",hue);
 	NSLogParam(@"\t\t sat",saturation);
 	NSLogParam(@"\t\t sharp",sharpness);
+	NSLogParam(@"\t\t gamma",gamma);
 	NSLogParam(@"\t\t auto wb",autoWhiteBalance);
 	NSLogParam(@"\t\t wb",whiteBalance);
 	NSLog(@"\t\t*******************");
@@ -1156,10 +1196,12 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 	[self _resetParamToDefault:&bright];
 	[self _resetParamToDefault:&contrast];
 	[self _resetParamToDefault:&gain];
+	[self _resetParamToDefault:&powerLine];
 	[self _resetParamToDefault:&autoHue];
 	[self _resetParamToDefault:&hue];
 	[self _resetParamToDefault:&saturation];
 	[self _resetParamToDefault:&sharpness];
+	[self _resetParamToDefault:&gamma];
 	[self _resetParamToDefault:&autoWhiteBalance];
 	[self _resetParamToDefault:&whiteBalance];
 }
@@ -1225,6 +1267,7 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 	if (![self _pushParamToDevice:&autoExposureMode])
 		[uiCtrlr _pushCameraControlStateToUI];	//	this is meant to "reload" the UI from the existing camera state if pushing a param failed (because the auto-exposure mode isn't supported).  this does not work- i think the USB device will accept the value, even though it isn't supported (the val is changing, but the behavior is simply unsupported)
 	
+	[self _pushParamToDevice:&exposureTime];
 	//if (oldVal != autoExposureMode.val && delegate!=nil)
 	//	[delegate VVUVCControllerParamsUpdated:self];
 }
@@ -1472,6 +1515,26 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 - (long) maxGain	{
 	return (!gain.supported) ? 0 : gain.max;
 }
+- (void) setPowerLine:(long)n	{
+	[self setVal:n forParam:&powerLine];
+}
+- (long) powerLine	{
+	if (!powerLine.supported)
+		return 0;
+	return powerLine.val;
+}
+- (BOOL) powerLineSupported	{
+	return powerLine.supported;
+}
+- (void) resetPowerLine	{
+	[self _resetParamToDefault:&powerLine];
+}
+- (long) minPowerLine {
+	return (!powerLine.supported) ? 0 : powerLine.min;
+}
+- (long) maxPowerLine {
+	return (!powerLine.supported) ? 0 : powerLine.max;
+}
 - (void) setAutoHue:(BOOL)n	{
 	//BOOL			changed = (autoHue.val != ((n) ? 0x01 : 0x00)) ? YES : NO;
 	autoHue.val = (n) ? 0x01 : 0x00;
@@ -1545,6 +1608,26 @@ uvc_control_info_t	_whiteBalanceTempCtrl;
 }
 - (long) maxSharpness	{
 	return (!sharpness.supported) ? 0 : sharpness.max;
+}
+- (void) setGamma:(long)n	{
+	[self setVal:n forParam:&gamma];
+}
+- (long) gamma	{
+	if (!gamma.supported)
+		return 0;
+	return gamma.val;
+}
+- (BOOL) gammaSupported	{
+	return gamma.supported;
+}
+- (void) resetGamma	{
+	[self _resetParamToDefault:&gamma];
+}
+- (long) minGamma	{
+	return (!gamma.supported) ? 0 : gamma.min;
+}
+- (long) maxGamma	{
+	return (!gamma.supported) ? 0 : gamma.max;
 }
 - (void) setAutoWhiteBalance:(BOOL)n	{
 	//BOOL			changed = (autoWhiteBalance.val != ((n) ? 0x01 : 0x00)) ? YES : NO;

--- a/VVUVCKit/VVUVCController.xib
+++ b/VVUVCKit/VVUVCController.xib
@@ -49,7 +49,7 @@
 				<int key="NSWindowBacking">2</int>
 				<string key="NSWindowRect">{{362, 760}, {396, 418}}</string>
 				<int key="NSWTFlags">1954021376</int>
-				<string key="NSWindowTitle">UVC Settings</string>
+				<string key="NSWindowTitle">Camera Settings</string>
 				<string key="NSWindowClass">NSPanel</string>
 				<nil key="NSViewClass"/>
 				<nil key="NSUserInterfaceItemIdentifier"/>

--- a/VVUVCKit/VVUVCController.xib
+++ b/VVUVCKit/VVUVCController.xib
@@ -1,1424 +1,237 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
-	<data>
-		<int key="IBDocument.SystemTarget">1080</int>
-		<string key="IBDocument.SystemVersion">12F45</string>
-		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.40</string>
-		<string key="IBDocument.HIToolboxVersion">626.00</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">3084</string>
-		</object>
-		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<string>NSButton</string>
-			<string>NSButtonCell</string>
-			<string>NSCustomObject</string>
-			<string>NSCustomView</string>
-			<string>NSMenu</string>
-			<string>NSMenuItem</string>
-			<string>NSPopUpButton</string>
-			<string>NSPopUpButtonCell</string>
-			<string>NSTextField</string>
-			<string>NSTextFieldCell</string>
-			<string>NSView</string>
-			<string>NSWindowTemplate</string>
-		</object>
-		<object class="NSArray" key="IBDocument.PluginDependencies">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-		</object>
-		<object class="NSMutableDictionary" key="IBDocument.Metadata">
-			<string key="NS.key.0">PluginDependencyRecalculationVersion</string>
-			<integer value="1" key="NS.object.0"/>
-		</object>
-		<object class="NSMutableArray" key="IBDocument.RootObjects" id="1000">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<object class="NSCustomObject" id="1001">
-				<string key="NSClassName">VVUVCController</string>
-			</object>
-			<object class="NSCustomObject" id="1003">
-				<string key="NSClassName">FirstResponder</string>
-			</object>
-			<object class="NSCustomObject" id="1004">
-				<string key="NSClassName">NSApplication</string>
-			</object>
-			<object class="NSWindowTemplate" id="69163892">
-				<int key="NSWindowStyleMask">15</int>
-				<int key="NSWindowBacking">2</int>
-				<string key="NSWindowRect">{{362, 760}, {396, 418}}</string>
-				<int key="NSWTFlags">1954021376</int>
-				<string key="NSWindowTitle">Camera Settings</string>
-				<string key="NSWindowClass">NSPanel</string>
-				<nil key="NSViewClass"/>
-				<nil key="NSUserInterfaceItemIdentifier"/>
-				<string key="NSWindowContentMinSize">{396, 418}</string>
-				<object class="NSView" key="NSWindowView" id="634037266">
-					<reference key="NSNextResponder"/>
-					<int key="NSvFlags">256</int>
-					<object class="NSMutableArray" key="NSSubviews">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSButton" id="806657760">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{235, 113}, {143, 18}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="448188100">
-								<int key="NSCellFlags">-2080374784</int>
-								<int key="NSCellFlags2">262144</int>
-								<string key="NSContents">Auto White Balance</string>
-								<object class="NSFont" key="NSSupport" id="22">
-									<string key="NSName">LucidaGrande</string>
-									<double key="NSSize">9</double>
-									<int key="NSfFlags">3614</int>
-								</object>
-								<reference key="NSControlView" ref="806657760"/>
-								<int key="NSButtonFlags">1211912448</int>
-								<int key="NSButtonFlags2">2</int>
-								<object class="NSCustomResource" key="NSNormalImage" id="53961061">
-									<string key="NSClassName">NSImage</string>
-									<string key="NSResourceName">NSSwitch</string>
-								</object>
-								<object class="NSButtonImageSource" key="NSAlternateImage" id="964229163">
-									<string key="NSImageName">NSSwitch</string>
-								</object>
-								<string key="NSAlternateContents"/>
-								<string key="NSKeyEquivalent"/>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSTextField" id="966800275">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{19, 369}, {138, 11}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="789320742"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSTextFieldCell" key="NSCell" id="306950940">
-								<int key="NSCellFlags">68157504</int>
-								<int key="NSCellFlags2">272892928</int>
-								<string key="NSContents">Exposure Mode:</string>
-								<reference key="NSSupport" ref="22"/>
-								<reference key="NSControlView" ref="966800275"/>
-								<object class="NSColor" key="NSBackgroundColor">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">controlColor</string>
-									<object class="NSColor" key="NSColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MC42NjY2NjY2NjY3AA</bytes>
-									</object>
-								</object>
-								<object class="NSColor" key="NSTextColor">
-									<int key="NSColorSpace">6</int>
-									<string key="NSCatalogName">System</string>
-									<string key="NSColorName">controlTextColor</string>
-									<object class="NSColor" key="NSColor">
-										<int key="NSColorSpace">3</int>
-										<bytes key="NSWhite">MAA</bytes>
-									</object>
-								</object>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSPopUpButton" id="762331525">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{19, 348}, {171, 15}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="481548528"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSPopUpButtonCell" key="NSCell" id="167146720">
-								<int key="NSCellFlags">-2076180416</int>
-								<int key="NSCellFlags2">264192</int>
-								<reference key="NSSupport" ref="22"/>
-								<reference key="NSControlView" ref="762331525"/>
-								<int key="NSButtonFlags">109199360</int>
-								<int key="NSButtonFlags2">129</int>
-								<string key="NSAlternateContents"/>
-								<string key="NSKeyEquivalent"/>
-								<int key="NSPeriodicDelay">400</int>
-								<int key="NSPeriodicInterval">75</int>
-								<object class="NSMenuItem" key="NSMenuItem" id="917300348">
-									<reference key="NSMenu" ref="252400124"/>
-									<string key="NSTitle">Auto</string>
-									<string key="NSKeyEquiv"/>
-									<int key="NSKeyEquivModMask">1048576</int>
-									<int key="NSMnemonicLoc">2147483647</int>
-									<int key="NSState">1</int>
-									<object class="NSCustomResource" key="NSOnImage" id="510888480">
-										<string key="NSClassName">NSImage</string>
-										<string key="NSResourceName">NSMenuCheckmark</string>
-									</object>
-									<object class="NSCustomResource" key="NSMixedImage" id="944371223">
-										<string key="NSClassName">NSImage</string>
-										<string key="NSResourceName">NSMenuMixedState</string>
-									</object>
-									<string key="NSAction">_popUpItemAction:</string>
-									<reference key="NSTarget" ref="167146720"/>
-								</object>
-								<bool key="NSMenuItemRespectAlignment">YES</bool>
-								<object class="NSMenu" key="NSMenu" id="252400124">
-									<string key="NSTitle">OtherViews</string>
-									<object class="NSMutableArray" key="NSMenuItems">
-										<bool key="EncodedWithXMLCoder">YES</bool>
-										<object class="NSMenuItem" id="593902933">
-											<reference key="NSMenu" ref="252400124"/>
-											<string key="NSTitle">Manual</string>
-											<string key="NSKeyEquiv"/>
-											<int key="NSKeyEquivModMask">1048576</int>
-											<int key="NSMnemonicLoc">2147483647</int>
-											<reference key="NSOnImage" ref="510888480"/>
-											<reference key="NSMixedImage" ref="944371223"/>
-											<string key="NSAction">_popUpItemAction:</string>
-											<reference key="NSTarget" ref="167146720"/>
-										</object>
-										<reference ref="917300348"/>
-										<object class="NSMenuItem" id="307713609">
-											<reference key="NSMenu" ref="252400124"/>
-											<string key="NSTitle">Shutter Priority</string>
-											<string key="NSKeyEquiv"/>
-											<int key="NSKeyEquivModMask">1048576</int>
-											<int key="NSMnemonicLoc">2147483647</int>
-											<reference key="NSOnImage" ref="510888480"/>
-											<reference key="NSMixedImage" ref="944371223"/>
-											<string key="NSAction">_popUpItemAction:</string>
-											<reference key="NSTarget" ref="167146720"/>
-										</object>
-										<object class="NSMenuItem" id="988632023">
-											<reference key="NSMenu" ref="252400124"/>
-											<string key="NSTitle">Aperture Priority</string>
-											<string key="NSKeyEquiv"/>
-											<int key="NSKeyEquivModMask">1048576</int>
-											<int key="NSMnemonicLoc">2147483647</int>
-											<reference key="NSOnImage" ref="510888480"/>
-											<reference key="NSMixedImage" ref="944371223"/>
-											<string key="NSAction">_popUpItemAction:</string>
-											<reference key="NSTarget" ref="167146720"/>
-										</object>
-									</object>
-									<bool key="NSNoAutoenable">YES</bool>
-									<object class="NSFont" key="NSMenuFont">
-										<string key="NSName">LucidaGrande</string>
-										<double key="NSSize">13</double>
-										<int key="NSfFlags">1044</int>
-									</object>
-								</object>
-								<int key="NSSelectedIndex">1</int>
-								<int key="NSPreferredEdge">1</int>
-								<bool key="NSUsesItemFromMenu">YES</bool>
-								<bool key="NSAltersState">YES</bool>
-								<int key="NSArrowPosition">2</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="852900846">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{41, 385}, {149, 18}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="966800275"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="236928970">
-								<int key="NSCellFlags">-2080374784</int>
-								<int key="NSCellFlags2">262144</int>
-								<string key="NSContents">Auto Exposure Priority</string>
-								<reference key="NSSupport" ref="22"/>
-								<reference key="NSControlView" ref="852900846"/>
-								<int key="NSButtonFlags">1211912448</int>
-								<int key="NSButtonFlags2">2</int>
-								<reference key="NSNormalImage" ref="53961061"/>
-								<reference key="NSAlternateImage" ref="964229163"/>
-								<string key="NSAlternateContents"/>
-								<string key="NSKeyEquivalent"/>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="22631078">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{41, 248}, {149, 18}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="676752848"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="1058272669">
-								<int key="NSCellFlags">-2080374784</int>
-								<int key="NSCellFlags2">262144</int>
-								<string key="NSContents">Auto Focus</string>
-								<reference key="NSSupport" ref="22"/>
-								<reference key="NSControlView" ref="22631078"/>
-								<int key="NSButtonFlags">1211912448</int>
-								<int key="NSButtonFlags2">2</int>
-								<reference key="NSNormalImage" ref="53961061"/>
-								<reference key="NSAlternateImage" ref="964229163"/>
-								<string key="NSAlternateContents"/>
-								<string key="NSKeyEquivalent"/>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="242679901">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{147, 19}, {102, 16}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="188006961">
-								<int key="NSCellFlags">67108864</int>
-								<int key="NSCellFlags2">134479872</int>
-								<string key="NSContents">Reset to Defaults!</string>
-								<reference key="NSSupport" ref="22"/>
-								<reference key="NSControlView" ref="242679901"/>
-								<int key="NSButtonFlags">-2038284288</int>
-								<int key="NSButtonFlags2">129</int>
-								<string key="NSAlternateContents"/>
-								<string key="NSKeyEquivalent"/>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSButton" id="917775730">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{235, 241}, {143, 18}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="805803933"/>
-							<bool key="NSEnabled">YES</bool>
-							<object class="NSButtonCell" key="NSCell" id="496365140">
-								<int key="NSCellFlags">-2080374784</int>
-								<int key="NSCellFlags2">262144</int>
-								<string key="NSContents">Auto Hue</string>
-								<reference key="NSSupport" ref="22"/>
-								<reference key="NSControlView" ref="917775730"/>
-								<int key="NSButtonFlags">1211912448</int>
-								<int key="NSButtonFlags2">2</int>
-								<reference key="NSNormalImage" ref="53961061"/>
-								<reference key="NSAlternateImage" ref="964229163"/>
-								<string key="NSAlternateContents"/>
-								<string key="NSKeyEquivalent"/>
-								<int key="NSPeriodicDelay">200</int>
-								<int key="NSPeriodicInterval">25</int>
-							</object>
-							<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
-						</object>
-						<object class="NSCustomView" id="481548528">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{20, 303}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="1048522982"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-						<object class="NSCustomView" id="795739316">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{20, 269}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="267883322"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-						<object class="NSCustomView" id="39659242">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{20, 209}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="917775730"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-						<object class="NSCustomView" id="805803933">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{20, 175}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="279976524"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-						<object class="NSCustomView" id="789320742">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{208, 364}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="762331525"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-						<object class="NSCustomView" id="1048522982">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{208, 330}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="795739316"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-						<object class="NSCustomView" id="267883322">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{208, 296}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="22631078"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-						<object class="NSCustomView" id="676752848">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{208, 262}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="39659242"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-						<object class="NSCustomView" id="279976524">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{208, 202}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="688682300"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-						<object class="NSCustomView" id="688682300">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{208, 168}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="607241549"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-						<object class="NSCustomView" id="607241549">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{208, 134}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView" ref="806657760"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-						<object class="NSCustomView" id="829136450">
-							<reference key="NSNextResponder" ref="634037266"/>
-							<int key="NSvFlags">268</int>
-							<string key="NSFrame">{{208, 74}, {168, 34}}</string>
-							<reference key="NSSuperview" ref="634037266"/>
-							<reference key="NSWindow"/>
-							<reference key="NSNextKeyView"/>
-							<string key="NSReuseIdentifierKey">_NS:9</string>
-							<string key="NSClassName">VVUVCUIElement</string>
-						</object>
-					</object>
-					<string key="NSFrameSize">{396, 418}</string>
-					<reference key="NSSuperview"/>
-					<reference key="NSWindow"/>
-					<reference key="NSNextKeyView" ref="852900846"/>
-				</object>
-				<string key="NSScreenRect">{{0, 0}, {1920, 1178}}</string>
-				<string key="NSMinSize">{396, 440}</string>
-				<string key="NSMaxSize">{10000000000000, 10000000000000}</string>
-				<bool key="NSWindowIsRestorable">YES</bool>
-			</object>
-			<object class="NSCustomObject" id="229897143">
-				<string key="NSClassName">VVUVCUIController</string>
-			</object>
-		</object>
-		<object class="IBObjectContainer" key="IBDocument.Objects">
-			<object class="NSMutableArray" key="connectionRecords">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">settingsWindow</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="69163892"/>
-					</object>
-					<int key="connectionID">104</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">settingsView</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="634037266"/>
-					</object>
-					<int key="connectionID">105</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">uiCtrlr</string>
-						<reference key="source" ref="1001"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">106</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">buttonUsed:</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="806657760"/>
-					</object>
-					<int key="connectionID">70</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">resetToDefaults:</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="242679901"/>
-					</object>
-					<int key="connectionID">71</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoWBButton</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="806657760"/>
-					</object>
-					<int key="connectionID">72</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoExpButton</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="762331525"/>
-					</object>
-					<int key="connectionID">82</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">buttonUsed:</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="852900846"/>
-					</object>
-					<int key="connectionID">86</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">buttonUsed:</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="917775730"/>
-					</object>
-					<int key="connectionID">88</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">popUpButtonUsed:</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="762331525"/>
-					</object>
-					<int key="connectionID">91</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBActionConnection" key="connection">
-						<string key="label">buttonUsed:</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="22631078"/>
-					</object>
-					<int key="connectionID">96</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">expPriorityButton</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="852900846"/>
-					</object>
-					<int key="connectionID">97</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoFocusButton</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="22631078"/>
-					</object>
-					<int key="connectionID">99</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">autoHueButton</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="917775730"/>
-					</object>
-					<int key="connectionID">100</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">device</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="1001"/>
-					</object>
-					<int key="connectionID">108</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">expElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="481548528"/>
-					</object>
-					<int key="connectionID">290</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">irisElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="795739316"/>
-					</object>
-					<int key="connectionID">291</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">focusElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="39659242"/>
-					</object>
-					<int key="connectionID">292</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">zoomElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="805803933"/>
-					</object>
-					<int key="connectionID">293</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">backlightElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="789320742"/>
-					</object>
-					<int key="connectionID">294</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">brightElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="1048522982"/>
-					</object>
-					<int key="connectionID">295</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">contrastElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="267883322"/>
-					</object>
-					<int key="connectionID">296</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">gainElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="676752848"/>
-					</object>
-					<int key="connectionID">297</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">hueElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="279976524"/>
-					</object>
-					<int key="connectionID">298</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">satElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="688682300"/>
-					</object>
-					<int key="connectionID">299</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">sharpElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="607241549"/>
-					</object>
-					<int key="connectionID">300</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">wbElement</string>
-						<reference key="source" ref="229897143"/>
-						<reference key="destination" ref="829136450"/>
-					</object>
-					<int key="connectionID">301</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="481548528"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">278</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="795739316"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">280</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="39659242"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">281</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="805803933"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">279</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="789320742"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">282</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="1048522982"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">283</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="267883322"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">284</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="676752848"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">285</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="279976524"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">286</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="688682300"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">287</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="607241549"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">288</int>
-				</object>
-				<object class="IBConnectionRecord">
-					<object class="IBOutletConnection" key="connection">
-						<string key="label">delegate</string>
-						<reference key="source" ref="829136450"/>
-						<reference key="destination" ref="229897143"/>
-					</object>
-					<int key="connectionID">289</int>
-				</object>
-			</object>
-			<object class="IBMutableOrderedSet" key="objectRecords">
-				<object class="NSArray" key="orderedObjects">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<object class="IBObjectRecord">
-						<int key="objectID">0</int>
-						<object class="NSArray" key="object" id="0">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-						</object>
-						<reference key="children" ref="1000"/>
-						<nil key="parent"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-2</int>
-						<reference key="object" ref="1001"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">File's Owner</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-1</int>
-						<reference key="object" ref="1003"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">First Responder</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">-3</int>
-						<reference key="object" ref="1004"/>
-						<reference key="parent" ref="0"/>
-						<string key="objectName">Application</string>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">3</int>
-						<reference key="object" ref="69163892"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="634037266"/>
-						</object>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">4</int>
-						<reference key="object" ref="229897143"/>
-						<reference key="parent" ref="0"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">5</int>
-						<reference key="object" ref="634037266"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="806657760"/>
-							<reference ref="966800275"/>
-							<reference ref="762331525"/>
-							<reference ref="852900846"/>
-							<reference ref="22631078"/>
-							<reference ref="917775730"/>
-							<reference ref="481548528"/>
-							<reference ref="795739316"/>
-							<reference ref="39659242"/>
-							<reference ref="805803933"/>
-							<reference ref="789320742"/>
-							<reference ref="1048522982"/>
-							<reference ref="267883322"/>
-							<reference ref="676752848"/>
-							<reference ref="279976524"/>
-							<reference ref="688682300"/>
-							<reference ref="607241549"/>
-							<reference ref="829136450"/>
-							<reference ref="242679901"/>
-						</object>
-						<reference key="parent" ref="69163892"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">6</int>
-						<reference key="object" ref="917775730"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="496365140"/>
-						</object>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">7</int>
-						<reference key="object" ref="242679901"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="188006961"/>
-						</object>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">14</int>
-						<reference key="object" ref="22631078"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="1058272669"/>
-						</object>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">17</int>
-						<reference key="object" ref="852900846"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="236928970"/>
-						</object>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">18</int>
-						<reference key="object" ref="762331525"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="167146720"/>
-						</object>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">19</int>
-						<reference key="object" ref="966800275"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="306950940"/>
-						</object>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">32</int>
-						<reference key="object" ref="806657760"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="448188100"/>
-						</object>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">38</int>
-						<reference key="object" ref="448188100"/>
-						<reference key="parent" ref="806657760"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">51</int>
-						<reference key="object" ref="306950940"/>
-						<reference key="parent" ref="966800275"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">52</int>
-						<reference key="object" ref="167146720"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="252400124"/>
-						</object>
-						<reference key="parent" ref="762331525"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">53</int>
-						<reference key="object" ref="252400124"/>
-						<object class="NSMutableArray" key="children">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<reference ref="988632023"/>
-							<reference ref="307713609"/>
-							<reference ref="917300348"/>
-							<reference ref="593902933"/>
-						</object>
-						<reference key="parent" ref="167146720"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">54</int>
-						<reference key="object" ref="988632023"/>
-						<reference key="parent" ref="252400124"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">55</int>
-						<reference key="object" ref="307713609"/>
-						<reference key="parent" ref="252400124"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">56</int>
-						<reference key="object" ref="917300348"/>
-						<reference key="parent" ref="252400124"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">57</int>
-						<reference key="object" ref="593902933"/>
-						<reference key="parent" ref="252400124"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">58</int>
-						<reference key="object" ref="236928970"/>
-						<reference key="parent" ref="852900846"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">61</int>
-						<reference key="object" ref="1058272669"/>
-						<reference key="parent" ref="22631078"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">68</int>
-						<reference key="object" ref="188006961"/>
-						<reference key="parent" ref="242679901"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">69</int>
-						<reference key="object" ref="496365140"/>
-						<reference key="parent" ref="917775730"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">263</int>
-						<reference key="object" ref="481548528"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">264</int>
-						<reference key="object" ref="795739316"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">265</int>
-						<reference key="object" ref="39659242"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">266</int>
-						<reference key="object" ref="805803933"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">267</int>
-						<reference key="object" ref="789320742"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">268</int>
-						<reference key="object" ref="1048522982"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">269</int>
-						<reference key="object" ref="267883322"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">270</int>
-						<reference key="object" ref="676752848"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">274</int>
-						<reference key="object" ref="279976524"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">275</int>
-						<reference key="object" ref="688682300"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">276</int>
-						<reference key="object" ref="607241549"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">277</int>
-						<reference key="object" ref="829136450"/>
-						<reference key="parent" ref="634037266"/>
-					</object>
-				</object>
-			</object>
-			<object class="NSMutableDictionary" key="flattenedProperties">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="NSArray" key="dict.sortedKeys">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<string>-1.IBPluginDependency</string>
-					<string>-2.IBPluginDependency</string>
-					<string>-3.IBPluginDependency</string>
-					<string>14.IBPluginDependency</string>
-					<string>17.IBPluginDependency</string>
-					<string>18.IBPluginDependency</string>
-					<string>19.IBPluginDependency</string>
-					<string>263.IBPluginDependency</string>
-					<string>264.IBPluginDependency</string>
-					<string>265.IBPluginDependency</string>
-					<string>266.IBPluginDependency</string>
-					<string>267.IBPluginDependency</string>
-					<string>268.IBPluginDependency</string>
-					<string>269.IBPluginDependency</string>
-					<string>270.IBPluginDependency</string>
-					<string>274.IBPluginDependency</string>
-					<string>275.IBPluginDependency</string>
-					<string>276.IBPluginDependency</string>
-					<string>277.IBPluginDependency</string>
-					<string>3.IBPluginDependency</string>
-					<string>3.IBWindowTemplateEditedContentRect</string>
-					<string>3.NSWindowTemplate.visibleAtLaunch</string>
-					<string>32.IBPluginDependency</string>
-					<string>38.IBPluginDependency</string>
-					<string>4.IBPluginDependency</string>
-					<string>5.IBPluginDependency</string>
-					<string>51.IBPluginDependency</string>
-					<string>52.IBPluginDependency</string>
-					<string>53.IBPluginDependency</string>
-					<string>54.IBPluginDependency</string>
-					<string>55.IBPluginDependency</string>
-					<string>56.IBPluginDependency</string>
-					<string>57.IBPluginDependency</string>
-					<string>58.IBPluginDependency</string>
-					<string>6.IBPluginDependency</string>
-					<string>61.IBPluginDependency</string>
-					<string>68.IBPluginDependency</string>
-					<string>69.IBPluginDependency</string>
-					<string>7.IBPluginDependency</string>
-				</object>
-				<object class="NSArray" key="dict.values">
-					<bool key="EncodedWithXMLCoder">YES</bool>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>{{312, 601}, {384, 389}}</string>
-					<boolean value="NO"/>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
-				</object>
-			</object>
-			<object class="NSMutableDictionary" key="unlocalizedProperties">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<reference key="dict.sortedKeys" ref="0"/>
-				<reference key="dict.values" ref="0"/>
-			</object>
-			<nil key="activeLocalization"/>
-			<object class="NSMutableDictionary" key="localizations">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<reference key="dict.sortedKeys" ref="0"/>
-				<reference key="dict.values" ref="0"/>
-			</object>
-			<nil key="sourceID"/>
-			<int key="maxID">301</int>
-		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<object class="IBPartialClassDescription">
-					<string key="className">VVUVCController</string>
-					<string key="superclassName">NSObject</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>settingsView</string>
-							<string>settingsWindow</string>
-							<string>uiCtrlr</string>
-						</object>
-						<object class="NSArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>NSView</string>
-							<string>NSWindow</string>
-							<string>id</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>settingsView</string>
-							<string>settingsWindow</string>
-							<string>uiCtrlr</string>
-						</object>
-						<object class="NSArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBToOneOutletInfo">
-								<string key="name">settingsView</string>
-								<string key="candidateClassName">NSView</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">settingsWindow</string>
-								<string key="candidateClassName">NSWindow</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">uiCtrlr</string>
-								<string key="candidateClassName">id</string>
-							</object>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/VVUVCController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">VVUVCUIController</string>
-					<string key="superclassName">NSObject</string>
-					<object class="NSMutableDictionary" key="actions">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>buttonUsed:</string>
-							<string>popUpButtonUsed:</string>
-							<string>resetToDefaults:</string>
-						</object>
-						<object class="NSArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>id</string>
-							<string>id</string>
-							<string>id</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="actionInfosByName">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>buttonUsed:</string>
-							<string>popUpButtonUsed:</string>
-							<string>resetToDefaults:</string>
-						</object>
-						<object class="NSArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBActionInfo">
-								<string key="name">buttonUsed:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">popUpButtonUsed:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBActionInfo">
-								<string key="name">resetToDefaults:</string>
-								<string key="candidateClassName">id</string>
-							</object>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="outlets">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>autoExpButton</string>
-							<string>autoFocusButton</string>
-							<string>autoHueButton</string>
-							<string>autoWBButton</string>
-							<string>backlightElement</string>
-							<string>brightElement</string>
-							<string>contrastElement</string>
-							<string>device</string>
-							<string>expElement</string>
-							<string>expPriorityButton</string>
-							<string>focusElement</string>
-							<string>gainElement</string>
-							<string>hueElement</string>
-							<string>irisElement</string>
-							<string>satElement</string>
-							<string>sharpElement</string>
-							<string>wbElement</string>
-							<string>zoomElement</string>
-						</object>
-						<object class="NSArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>NSPopUpButton</string>
-							<string>NSButton</string>
-							<string>NSButton</string>
-							<string>NSButton</string>
-							<string>VVUVCUIElement</string>
-							<string>VVUVCUIElement</string>
-							<string>VVUVCUIElement</string>
-							<string>id</string>
-							<string>VVUVCUIElement</string>
-							<string>NSButton</string>
-							<string>VVUVCUIElement</string>
-							<string>VVUVCUIElement</string>
-							<string>VVUVCUIElement</string>
-							<string>VVUVCUIElement</string>
-							<string>VVUVCUIElement</string>
-							<string>VVUVCUIElement</string>
-							<string>VVUVCUIElement</string>
-							<string>VVUVCUIElement</string>
-						</object>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<bool key="EncodedWithXMLCoder">YES</bool>
-						<object class="NSArray" key="dict.sortedKeys">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<string>autoExpButton</string>
-							<string>autoFocusButton</string>
-							<string>autoHueButton</string>
-							<string>autoWBButton</string>
-							<string>backlightElement</string>
-							<string>brightElement</string>
-							<string>contrastElement</string>
-							<string>device</string>
-							<string>expElement</string>
-							<string>expPriorityButton</string>
-							<string>focusElement</string>
-							<string>gainElement</string>
-							<string>hueElement</string>
-							<string>irisElement</string>
-							<string>satElement</string>
-							<string>sharpElement</string>
-							<string>wbElement</string>
-							<string>zoomElement</string>
-						</object>
-						<object class="NSArray" key="dict.values">
-							<bool key="EncodedWithXMLCoder">YES</bool>
-							<object class="IBToOneOutletInfo">
-								<string key="name">autoExpButton</string>
-								<string key="candidateClassName">NSPopUpButton</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">autoFocusButton</string>
-								<string key="candidateClassName">NSButton</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">autoHueButton</string>
-								<string key="candidateClassName">NSButton</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">autoWBButton</string>
-								<string key="candidateClassName">NSButton</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">backlightElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">brightElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">contrastElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">device</string>
-								<string key="candidateClassName">id</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">expElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">expPriorityButton</string>
-								<string key="candidateClassName">NSButton</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">focusElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">gainElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">hueElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">irisElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">satElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">sharpElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">wbElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-							<object class="IBToOneOutletInfo">
-								<string key="name">zoomElement</string>
-								<string key="candidateClassName">VVUVCUIElement</string>
-							</object>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/VVUVCUIController.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">VVUVCUIElement</string>
-					<string key="superclassName">NSBox</string>
-					<object class="NSMutableDictionary" key="outlets">
-						<string key="NS.key.0">delegate</string>
-						<string key="NS.object.0">id</string>
-					</object>
-					<object class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<string key="NS.key.0">delegate</string>
-						<object class="IBToOneOutletInfo" key="NS.object.0">
-							<string key="name">delegate</string>
-							<string key="candidateClassName">id</string>
-						</object>
-					</object>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/VVUVCUIElement.h</string>
-					</object>
-				</object>
-			</object>
-		</object>
-		<int key="IBDocument.localizationMode">0</int>
-		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaFramework</string>
-		<object class="NSMutableDictionary" key="IBDocument.PluginDeclaredDevelopmentDependencies">
-			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin.InterfaceBuilder3</string>
-			<integer value="3000" key="NS.object.0"/>
-		</object>
-		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
-		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<object class="NSMutableDictionary" key="IBDocument.LastKnownImageSizes">
-			<bool key="EncodedWithXMLCoder">YES</bool>
-			<object class="NSArray" key="dict.sortedKeys">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<string>NSMenuCheckmark</string>
-				<string>NSMenuMixedState</string>
-				<string>NSSwitch</string>
-			</object>
-			<object class="NSArray" key="dict.values">
-				<bool key="EncodedWithXMLCoder">YES</bool>
-				<string>{11, 11}</string>
-				<string>{10, 3}</string>
-				<string>{15, 15}</string>
-			</object>
-		</object>
-	</data>
-</archive>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="10116"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="VVUVCController">
+            <connections>
+                <outlet property="settingsView" destination="5" id="105"/>
+                <outlet property="settingsWindow" destination="3" id="104"/>
+                <outlet property="uiCtrlr" destination="4" id="106"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Camera Settings" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="3" customClass="NSPanel">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="784" y="313" width="396" height="364"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
+            <value key="minSize" type="size" width="396" height="364"/>
+            <view key="contentView" id="5">
+                <rect key="frame" x="0.0" y="0.0" width="396" height="364"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <button id="32">
+                        <rect key="frame" x="235" y="59" width="143" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Auto White Balance" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="mini" state="on" inset="2" id="38">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="miniSystem"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="buttonUsed:" target="4" id="70"/>
+                        </connections>
+                    </button>
+                    <textField verticalHuggingPriority="750" id="19">
+                        <rect key="frame" x="18" y="305" width="138" height="11"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Exposure Mode:" id="51">
+                            <font key="font" metaFont="miniSystem"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <popUpButton verticalHuggingPriority="750" id="18">
+                        <rect key="frame" x="19" y="284" width="171" height="15"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <popUpButtonCell key="cell" type="push" title="Auto" bezelStyle="rounded" alignment="left" controlSize="mini" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" autoenablesItems="NO" selectedItem="56" id="52">
+                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="miniSystem"/>
+                            <menu key="menu" title="OtherViews" autoenablesItems="NO" id="53">
+                                <items>
+                                    <menuItem title="Manual" id="57"/>
+                                    <menuItem title="Auto" state="on" id="56"/>
+                                    <menuItem title="Shutter Priority" id="55"/>
+                                    <menuItem title="Aperture Priority" id="54"/>
+                                </items>
+                            </menu>
+                        </popUpButtonCell>
+                        <connections>
+                            <action selector="popUpButtonUsed:" target="4" id="91"/>
+                        </connections>
+                    </popUpButton>
+                    <button id="17">
+                        <rect key="frame" x="110" y="302" width="80" height="19"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Auto Priority" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="mini" state="on" inset="2" id="58">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="miniSystem"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="buttonUsed:" target="4" id="86"/>
+                        </connections>
+                    </button>
+                    <button id="14">
+                        <rect key="frame" x="41" y="187" width="80" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Auto Focus" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="mini" state="on" inset="2" id="61">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="miniSystem"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="buttonUsed:" target="4" id="96"/>
+                        </connections>
+                    </button>
+                    <button id="6">
+                        <rect key="frame" x="235" y="187" width="143" height="18"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="check" title="Auto Hue" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="mini" state="on" inset="2" id="69">
+                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                            <font key="font" metaFont="miniSystem"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="buttonUsed:" target="4" id="88"/>
+                        </connections>
+                    </button>
+                    <customView id="263" customClass="VVUVCUIElement">
+                        <rect key="frame" x="20" y="242" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="278"/>
+                        </connections>
+                    </customView>
+                    <customView id="264" customClass="VVUVCUIElement">
+                        <rect key="frame" x="20" y="208" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="280"/>
+                        </connections>
+                    </customView>
+                    <customView id="265" customClass="VVUVCUIElement">
+                        <rect key="frame" x="20" y="148" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="281"/>
+                        </connections>
+                    </customView>
+                    <customView id="266" customClass="VVUVCUIElement">
+                        <rect key="frame" x="20" y="114" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="279"/>
+                        </connections>
+                    </customView>
+                    <customView id="267" customClass="VVUVCUIElement">
+                        <rect key="frame" x="208" y="310" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="282"/>
+                        </connections>
+                    </customView>
+                    <customView id="268" customClass="VVUVCUIElement">
+                        <rect key="frame" x="208" y="276" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="283"/>
+                        </connections>
+                    </customView>
+                    <customView id="269" customClass="VVUVCUIElement">
+                        <rect key="frame" x="208" y="242" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="284"/>
+                        </connections>
+                    </customView>
+                    <customView id="270" customClass="VVUVCUIElement">
+                        <rect key="frame" x="208" y="208" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="285"/>
+                        </connections>
+                    </customView>
+                    <customView id="274" customClass="VVUVCUIElement">
+                        <rect key="frame" x="208" y="148" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="286"/>
+                        </connections>
+                    </customView>
+                    <customView id="275" customClass="VVUVCUIElement">
+                        <rect key="frame" x="208" y="114" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="287"/>
+                        </connections>
+                    </customView>
+                    <customView id="276" customClass="VVUVCUIElement">
+                        <rect key="frame" x="208" y="80" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="288"/>
+                        </connections>
+                    </customView>
+                    <customView id="277" customClass="VVUVCUIElement">
+                        <rect key="frame" x="208" y="20" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="289"/>
+                        </connections>
+                    </customView>
+                    <customView id="XQj-Gv-sNM" customClass="VVUVCUIElement">
+                        <rect key="frame" x="20" y="80" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="CJi-lu-pBj"/>
+                        </connections>
+                    </customView>
+                    <button verticalHuggingPriority="750" id="7">
+                        <rect key="frame" x="53" y="328" width="102" height="16"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <buttonCell key="cell" type="push" title="Reset to Defaults" bezelStyle="rounded" alignment="center" controlSize="mini" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="68">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="miniSystem"/>
+                        </buttonCell>
+                        <connections>
+                            <action selector="resetToDefaults:" target="4" id="71"/>
+                        </connections>
+                    </button>
+                    <customView id="Pxn-LE-Cmk" customClass="VVUVCUIElement">
+                        <rect key="frame" x="20" y="20" width="168" height="34"/>
+                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="4" id="y2U-D2-yhd"/>
+                        </connections>
+                    </customView>
+                </subviews>
+            </view>
+            <point key="canvasLocation" x="556" y="260"/>
+        </window>
+        <customObject id="4" customClass="VVUVCUIController">
+            <connections>
+                <outlet property="autoExpButton" destination="18" id="82"/>
+                <outlet property="autoFocusButton" destination="14" id="99"/>
+                <outlet property="autoHueButton" destination="6" id="100"/>
+                <outlet property="autoWBButton" destination="32" id="72"/>
+                <outlet property="backlightElement" destination="267" id="294"/>
+                <outlet property="brightElement" destination="268" id="295"/>
+                <outlet property="contrastElement" destination="269" id="296"/>
+                <outlet property="device" destination="-2" id="108"/>
+                <outlet property="expElement" destination="263" id="290"/>
+                <outlet property="expPriorityButton" destination="17" id="97"/>
+                <outlet property="focusElement" destination="265" id="292"/>
+                <outlet property="gainElement" destination="270" id="297"/>
+                <outlet property="gammaElement" destination="XQj-Gv-sNM" id="4Ia-iT-QdE"/>
+                <outlet property="hueElement" destination="274" id="298"/>
+                <outlet property="irisElement" destination="264" id="291"/>
+                <outlet property="powerElement" destination="Pxn-LE-Cmk" id="M7l-QN-0hS"/>
+                <outlet property="satElement" destination="275" id="299"/>
+                <outlet property="sharpElement" destination="276" id="300"/>
+                <outlet property="wbElement" destination="277" id="301"/>
+                <outlet property="zoomElement" destination="266" id="293"/>
+            </connections>
+        </customObject>
+    </objects>
+</document>

--- a/VVUVCKit/VVUVCKit-Info.plist
+++ b/VVUVCKit/VVUVCKit-Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.Vidvox.${PRODUCT_NAME:rfc1034identifier}</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/VVUVCKit/VVUVCUIController.h
+++ b/VVUVCKit/VVUVCUIController.h
@@ -25,10 +25,12 @@
 	IBOutlet VVUVCUIElement		*backlightElement;
 	IBOutlet VVUVCUIElement		*brightElement;
 	IBOutlet VVUVCUIElement		*contrastElement;
-	IBOutlet VVUVCUIElement		*gainElement;
+	IBOutlet VVUVCUIElement		*powerElement;
+	IBOutlet VVUVCUIElement		*gammaElement;
 	IBOutlet VVUVCUIElement		*hueElement;
 	IBOutlet VVUVCUIElement		*satElement;
 	IBOutlet VVUVCUIElement		*sharpElement;
+	IBOutlet VVUVCUIElement		*gainElement;
 	IBOutlet VVUVCUIElement		*wbElement;
 }
 

--- a/VVUVCKit/VVUVCUIController.m
+++ b/VVUVCKit/VVUVCUIController.m
@@ -25,9 +25,11 @@
 	[brightElement setTitle:@"Brightness"];
 	[contrastElement setTitle:@"Contrast"];
 	[gainElement setTitle:@"Gain"];
+	[powerElement setTitle:@"Power Line Frequency"];
 	[hueElement setTitle:@"Hue"];
 	[satElement setTitle:@"Saturation"];
 	[sharpElement setTitle:@"Sharpness"];
+	[gammaElement setTitle:@"Gamma"];
 	[wbElement setTitle:@"White Balance"];
 }
 - (void) dealloc	{
@@ -61,6 +63,9 @@
 	else if (sender == gainElement)	{
 		[device setGain:[sender val]];
 	}
+	else if (sender == powerElement)	{
+		[device setPowerLine:[sender val]];
+	}
 	else if (sender == hueElement)	{
 		[device setHue:[sender val]];
 	}
@@ -69,6 +74,9 @@
 	}
 	else if (sender == sharpElement)	{
 		[device setSharpness:[sender val]];
+	}
+	else if (sender == gammaElement)	{
+		[device setGamma:[sender val]];
 	}
 	else if (sender == wbElement)	{
 		[device setWhiteBalance:[sender val]];
@@ -165,7 +173,7 @@
 		[backlightElement setMax:(int)[device maxBacklight]];
 		[backlightElement setVal:(int)[device backlight]];
 	}
-	[backlightElement setEnabled:[device backlight]];
+	[backlightElement setEnabled:[device backlightSupported]];
 
 	if ([device brightSupported])	{
 		[brightElement setMin:(int)[device minBright]];
@@ -188,6 +196,13 @@
 	}
 	[gainElement setEnabled:[device gainSupported]];
 
+	if ([device powerLineSupported])	{
+		[powerElement setMin:(int)[device minPowerLine]];
+		[powerElement setMax:(int)[device maxPowerLine]];
+		[powerElement setVal:(int)[device powerLine]];
+	}
+	[powerElement setEnabled:[device powerLineSupported]];
+	
 	if ([device saturationSupported])	{
 		[satElement setMin:(int)[device minSaturation]];
 		[satElement setMax:(int)[device maxSaturation]];
@@ -202,8 +217,11 @@
 	}
 	[sharpElement setEnabled:[device sharpnessSupported]];
 
-	
-	
+	if ([device gammaSupported])	{
+		[gammaElement setMin:(int)[device minGamma]];
+		[gammaElement setMax:(int)[device maxGamma]];
+		[gammaElement setVal:(int)[device gamma]];
+	}
 	
 	[expPriorityButton setEnabled:[device autoExposurePrioritySupported]];
 	[expPriorityButton setIntValue:([device autoExposurePriority]) ? NSOnState : NSOffState];
@@ -211,15 +229,7 @@
 	[autoFocusButton setEnabled:([device autoFocusSupported]) ? YES : NO];
 	[autoFocusButton setIntValue:([device autoFocus]) ? NSOnState : NSOffState];
 	
-
 	
-
-
-
-
-
-
-
 	BOOL			enableFocusElement = NO;
 	if ([device autoFocusSupported])	{
 		[autoFocusButton setEnabled:YES];
@@ -234,6 +244,7 @@
 	}
 	else	{
 		[autoFocusButton setEnabled:NO];
+		[autoFocusButton setIntValue:NSOffState];
 		if ([device focusSupported])
 			enableFocusElement = YES;
 	}
@@ -242,10 +253,9 @@
 		[focusElement setMin:(int)[device minFocus]];
 		[focusElement setMax:(int)[device maxFocus]];
 		[focusElement setVal:(int)[device focus]];
-	}
+	} else [focusElement setVal:0];
 
-
-
+	
 	BOOL			enableHueElement = NO;
 	if ([device autoHueSupported])	{
 		[autoHueButton setEnabled:YES];
@@ -260,6 +270,7 @@
 	}
 	else	{
 		[autoHueButton setEnabled:NO];
+		[autoHueButton setIntValue:NSOffState];
 		if ([device hueSupported])
 			enableHueElement = YES;
 	}
@@ -268,8 +279,7 @@
 		[hueElement setMin:(int)[device minHue]];
 		[hueElement setMax:(int)[device maxHue]];
 		[hueElement setVal:(int)[device hue]];
-	}
-
+	} else [hueElement setVal:0];
 
 
 	BOOL			enableWBElement = NO;
@@ -286,6 +296,7 @@
 	}
 	else	{
 		[autoWBButton setEnabled:NO];
+		[autoWBButton setIntValue:NSOffState];
 		if ([device whiteBalanceSupported])
 			enableWBElement = YES;
 	}
@@ -294,8 +305,7 @@
 		[wbElement setMin:(int)[device minWhiteBalance]];
 		[wbElement setMax:(int)[device maxWhiteBalance]];
 		[wbElement setVal:(int)[device whiteBalance]];
-	}
-
+	} else [wbElement setVal:0];
 
 
 	UVC_AEMode		aeMode = [device autoExposureMode];
@@ -314,6 +324,7 @@
 			[autoExpButton selectItemAtIndex:1];
 			[expElement setEnabled:NO];
 			[irisElement setEnabled:NO];
+			[expElement setVal:0];
 			break;
 		case UVC_AEMode_ShutterPriority:
 			[autoExpButton selectItemAtIndex:2];
@@ -324,6 +335,7 @@
 			[autoExpButton selectItemAtIndex:3];
 			[expElement setEnabled:NO];
 			[irisElement setEnabled:(YES && [device irisSupported])];
+			[expElement setVal:0];
 			break;
 	}
 }


### PR DESCRIPTION
This patch implements the missing GAMMA and POWERLINE configuration options.
As a consequence the GUI has been also updated accordingly, also with a more compact layout.
Finally this patch also mutes a few of the more verbose warnings ...

I have am using your Framework in reacTIVision, 
many thanks for bringing proper UVC camera configuration to the Mac.
https://github.com/mkalten/reacTIVision
